### PR TITLE
Fix move up event if move type === 'content'

### DIFF
--- a/src/vue-bottom-sheet.vue
+++ b/src/vue-bottom-sheet.vue
@@ -95,6 +95,9 @@ export default {
     },
     move(event, type) {
       let delta = -event.deltaY;
+      if (type === "content" && this.contentScroll === 0) {
+        type = "pan";
+      }
       if (
         (type === 'content' && event.type === 'panup') ||
         (type === 'content' && event.type === 'pandown' && this.contentScroll > 0)


### PR DESCRIPTION
Когда зажимаешь 'pan' и проводишь его вниз, затем вверх, bottom sheet ведет себя нормально и следует за пальцем, но когда зажимаешь 'content' проводишь его вниз, затем вверх, bottom sheet не следует за пальцем вверх.